### PR TITLE
swallows logstash redis connection errors and retries every 5 seconds

### DIFF
--- a/lib/logstash.js
+++ b/lib/logstash.js
@@ -23,7 +23,10 @@ var Logstash = module.exports = function (opts, name) {
         this.port = opts.port || 6379;
         this.channel = opts.hasOwnProperty('channel') ? opts.channel : true;
         this.list = !this.channel;
-        this.client = redis.createClient(this.port, this.host);
+        this.client = redis.createClient(this.port, this.host, {retry_max_delay: 5000});
+        this.client.on('error', function (err) {
+          //swallow error and let it keep retrying
+        });
     } else if (opts.udp) {
         dgram = require('dgram');
         this.udp = true;


### PR DESCRIPTION
for https://github.com/nlf/bucker/issues/22

Of course, the fact that this is failing should be logged somewhere, but error logging inside of a logging library is somewhat problematic. It might be possible to log to self (thought that's not `this` here), and if the user has file logging or something else, then the error will get logged there.
