### PR TITLE
Teach logStash to optionally log to a local file

### DIFF
--- a/lib/logstash.js
+++ b/lib/logstash.js
@@ -33,6 +33,15 @@ var Logstash = module.exports = function (opts, name) {
         this.port = opts.port || 9999;
         this.client = dgram.createSocket('udp4');
     }
+    if (opts.file) {
+        var mkdirp = require('mkdirp'),
+            path = require('path'),
+            fs = require('fs');
+
+        this.filename = opts.file || 'logstash.log';
+        mkdirp.sync(path.dirname(this.filename));
+        this.filestream = fs.createWriteStream(this.filename, { encoding: 'utf8', flags: 'a+' });
+    }
 
 };
 
@@ -122,5 +131,8 @@ Logstash.prototype.send = function (data) {
     } else if (this.udp) {
         packet = new Buffer(packet);
         this.client.send(packet, 0, packet.length, this.port, this.host); 
+    }
+    if (this.filename) {
+        this.filestream.write(packet + '\n');
     }
 };


### PR DESCRIPTION
This change leverages the logstash writer to write to a log file using the logstash format.

This change allows for a `file` key to define an output log file that will be written to independently of the redis or udp settings.
- Example usage:

``` json
{
    "logstash": {
         "file": "/var/log/app/logstash.log"
    }
}
```
