### PR TITLE
Teach logStash to accept static key/values from the config file

### DIFF
--- a/lib/logstash.js
+++ b/lib/logstash.js
@@ -16,6 +16,11 @@ var Logstash = module.exports = function (opts, name) {
     this.source = opts.source;
     this.source_host = opts.source_host;
 
+    // Static key/value pairs to always put into the log
+    if (opts.static_keys) {
+        this.static_keys = opts.static_keys;
+    }
+
     if (opts.redis) {
         loadRedis();
         this.redis = true;
@@ -111,6 +116,14 @@ Logstash.prototype.stat = function (time, module, statName, type, value, tags) {
 };
 
 Logstash.prototype.send = function (data) {
+    // Always include static key/values in the log output
+    if (this.static_keys) {
+        for (var k in this.static_keys) {
+            if (this.static_keys.hasOwnProperty(k) && !data['@' + k])
+                data['@' + k] = this.static_keys[k];
+        }
+    }
+
     var packet = JSON.stringify(data);
 
     if (this.redis) {


### PR DESCRIPTION
This PR gives the `logstash` writer the ability to write a static list of key-value pairs to each log entry.  This allows for custom configuration file to be written on different servers/environments that will contain static data to log, such as the server name, ip address, or other important server-specific information.

One way to leverage this change is to use the npm `config` module with a default bucker configuration section and override that using a separate config per environment and server.
- Example:

```
{
    "logstash": {
        "static_keys": {
            "hostname": "host.domain.com",
        }
    }
}
```
