### PR TITLE
plugin.events is deprecated in Hapi 8.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -377,7 +377,7 @@ Bucker.prototype.email = function () {
 };
 
 // Hapi plugin
-exports.register = function (plugin, options, next) {
+exports.register = function (server, options, next) {
     // get/make bucker object
     var bucker;
 
@@ -407,7 +407,7 @@ exports.register = function (plugin, options, next) {
     }
 
     // access logger
-    plugin.events.on('request', function (request, event, tags) {
+    server.on('request', function (request, event, tags) {
         var level;
         //First check for hapi response events
         if (tags.hapi && tags.response) {
@@ -432,16 +432,16 @@ exports.register = function (plugin, options, next) {
     });
     // add listener by default but dont if its false
     if (!options.hapi || (options.hapi && options.hapi.handleLog)) {
-        plugin.events.on('log', function (event, tags, timestamp) {
+        server.on('log', function (event, tags, timestamp) {
             hapiLog(event, tags);
         });
 
-        plugin.events.on('internalError', function (event, error) {
+        server.on('internalError', function (event, error) {
             bucker.exception({ message: error.message, stack: error.stack });
         });
     }
     // and attach ourselves to server.plugins.bucker
-    plugin.expose(bucker);
+    server.expose(bucker);
     return next();
 };
 exports.register.attributes = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bucker",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "super easy logging module",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
`plugin.events.on` were deprecated in Hapi 8.0.0 and also the variable referring to the plugin has been replaced with server to stay in line with Hapi conventions.