### PR TITLE
add riemann to the list of transports

### DIFF
--- a/transports/riemann.js
+++ b/transports/riemann.js
@@ -1,0 +1,39 @@
+var protobuf = require('protobuf.js');
+var proto2json = require('node-proto2json');
+var Joi = require('joi');
+
+var riemann = require('../lib/baseTransport').extend(function () {
+
+    this.client = Dgram.createSocket('udp4');
+    this.client.unref(); // don't hold the process open
+    this.pb;
+
+    proto2json.parse(fs.readFileSync('./riemann.proto', 'utf8'), function cb(err, result) {
+        this.pb = new protobuff(result);
+    });
+});
+
+riemann.prototype.validate = function (options, callback) {
+
+    var schema = Joi.object().keys({
+        host: Joi.string().hostname().default('127.0.0.1'),
+        port: Joi.number().integer().default(5555)
+    });
+
+    schema.validate(options, callback);
+};
+
+riemann.prototype.stat = function (name, timestamp, tags, data) {
+
+    var self = this;
+
+    self.client.ref(); // make sure we send this packet
+    var payload = self.pb.encode('Event', { time: timestamp, state: 'ok', host: name, tags: tags, service: data[0], metric_d: data[1] });
+    var packet = new Buffer(payload);
+
+    self.client.send(packet, 0, packet.length, self.options.port, self.options.host, function () {
+        self.client.unref(); // and stop holding the process open again
+    });
+};
+
+module.exports = riemann;

--- a/transports/riemann.proto
+++ b/transports/riemann.proto
@@ -1,0 +1,31 @@
+message Event {
+  optional int64 time = 1;
+  optional string state = 2;
+  optional string service = 3;
+  optional string host = 4;
+  optional string description = 5;
+  repeated string tags = 7;
+  optional float ttl = 8;
+  repeated Attribute attributes = 9;
+
+  optional sint64 metric_sint64 = 13;
+  optional double metric_d = 14;
+  optional float metric_f = 15;
+}
+
+message Query {
+  optional string string = 1;
+}
+
+message Msg {
+  optional bool ok = 2;
+  optional string error = 3;
+  repeated State states = 4;
+  optional Query query = 5;
+  repeated Event events = 6;
+}
+
+message Attribute {
+  required string key = 1;
+  optional string value = 2;
+}


### PR DESCRIPTION
I know the js syntax is probably wrong in quite a few spots...

but from what I could see in http://riemann.io/howto.html#write-a-client this should send over UDP a Riemann Event message for each call to .stat()
